### PR TITLE
Fixed header tags for Markdown Cheatsheet.

### DIFF
--- a/lib/markdown_deux/templates/markdown_deux/markdown_cheatsheet.html
+++ b/lib/markdown_deux/templates/markdown_deux/markdown_cheatsheet.html
@@ -1,5 +1,5 @@
 <div class="cheatsheet">
-<h2>Markdown Cheatsheet</h3>
+<h2>Markdown Cheatsheet</h2>
 
 <h3>Phrase Emphasis</h3>
 


### PR DESCRIPTION
Updated the cheatsheet. Markdown Cheatsheet closing tag was </h3>, should be </h2>.
